### PR TITLE
Style range sliders with black accent

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  input[type='range'] {
+    @apply accent-black;
+  }
+}


### PR DESCRIPTION
## Summary
- apply black accent color to all range inputs for consistent slider styling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689f665f02d48329a899c2aa68283e44